### PR TITLE
Cms Player & Monster

### DIFF
--- a/Assets/CMS/AttackState.cs
+++ b/Assets/CMS/AttackState.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using UnityEngine;
+
+public class AttackState : MonoBehaviour, IState
+{
+    private Monster _monster;
+    private float _attackCooldown = 1.5f;
+    private float _lastAttackTime;
+    public void EnterState()
+    {
+        if (!_monster) _monster = GetComponent<Monster>();
+        _lastAttackTime = Time.time - _attackCooldown; // 바로 공격할 수 있게 초기화
+    }
+    public void UpdateState()
+    {
+        if (Time.time >= _lastAttackTime + _attackCooldown)
+        {
+            Debug.Log("몬스터 : 공격 !");
+            _lastAttackTime = Time.time;
+        }
+        
+    }
+    public void ExitState()
+    {
+        
+    }
+}

--- a/Assets/CMS/AttackState.cs.meta
+++ b/Assets/CMS/AttackState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 965e41df8d6054d48bf7ac95f54608d7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/CMS_TestScene.unity
+++ b/Assets/CMS/CMS_TestScene.unity
@@ -122,7 +122,7 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &506210960
+--- !u!1 &178331958
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -130,22 +130,37 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 506210962}
-  - component: {fileID: 506210961}
+  - component: {fileID: 178331959}
+  - component: {fileID: 178331960}
   m_Layer: 0
-  m_Name: Capsule
+  m_Name: 9-Sliced
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &506210961
+--- !u!4 &178331959
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 178331958}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.11, y: 0.28, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.25, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 506210962}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &178331960
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 506210960}
+  m_GameObject: {fileID: 178331958}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -180,32 +195,22 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -9095717837082945937, guid: 207ee8102dd4143d288186ef0be518ee, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: -5177388603050735206, guid: 8884154dfe85442a3a3578be807dbcdf, type: 3}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
   m_FlipX: 0
   m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 2}
+  m_DrawMode: 2
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!4 &506210962
+--- !u!4 &506210962 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+  m_PrefabInstance: {fileID: 7204486538527988661}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 506210960}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1726532817
 GameObject:
   m_ObjectHideFlags: 0
@@ -217,6 +222,7 @@ GameObject:
   - component: {fileID: 1726532820}
   - component: {fileID: 1726532819}
   - component: {fileID: 1726532818}
+  - component: {fileID: 1726532821}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -298,9 +304,84 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1726532821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1726532817}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 45bfea4d988e904438867b51496d9317, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  target: {fileID: 506210962}
+  offset: {x: 0, y: 0, z: -10}
+  smoothSpeed: 5
+--- !u!1001 &7204486538527988661
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9162771540310933599, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 6510858786333333916, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 178331959}
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 39a948792fb5ae148bcc2186517eb9cd, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1726532820}
-  - {fileID: 506210962}
+  - {fileID: 7204486538527988661}

--- a/Assets/CMS/CMS_TestScene.unity
+++ b/Assets/CMS/CMS_TestScene.unity
@@ -122,6 +122,90 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &506210960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 506210962}
+  - component: {fileID: 506210961}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &506210961
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506210960}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -9095717837082945937, guid: 207ee8102dd4143d288186ef0be518ee, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &506210962
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506210960}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1726532817
 GameObject:
   m_ObjectHideFlags: 0
@@ -219,3 +303,4 @@ SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
   - {fileID: 1726532820}
+  - {fileID: 506210962}

--- a/Assets/CMS/ChaseState.cs
+++ b/Assets/CMS/ChaseState.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ChaseState : MonoBehaviour, IState
+{
+    private Monster _monster;
+    private Rigidbody2D _rb;
+    private Transform _target;
+
+    [SerializeField] private float _chaseSpeed = 3.5f;
+    public void EnterState()
+    {
+        if (!_monster) _monster = GetComponent<Monster>();
+        if (!_rb) _rb = GetComponent<Rigidbody2D>();
+        if (!_target) _target = _monster.Player;
+    }
+
+    public void UpdateState()
+    {
+        if (_target == null) return;
+
+        Vector2 direction = (_target.position - transform.position).normalized;
+        _rb.MovePosition(_rb.position + direction * _chaseSpeed * Time.fixedDeltaTime);
+    }
+
+    public void ExitState()
+    {
+
+    }
+}
+

--- a/Assets/CMS/ChaseState.cs.meta
+++ b/Assets/CMS/ChaseState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f7a32615c28d2148bf20b11eb4930e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/FollowCamera.cs
+++ b/Assets/CMS/FollowCamera.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FollowCamera : MonoBehaviour
+{
+    [SerializeField] private Transform target;
+    [SerializeField] private Vector3 offset = new Vector3(0, 0, -10); // Z축만 이동 (2D 전용)
+    [SerializeField] private float smoothSpeed = 5f;
+
+    private void LateUpdate()
+    {
+        if (target != null)
+        {
+            // Z축 고정, X/Y 따라감
+            Vector3 desiredPosition = new Vector3(target.position.x + offset.x, target.position.y + offset.y, offset.z);
+            transform.position = Vector3.Lerp(transform.position, desiredPosition, Time.deltaTime * smoothSpeed);
+        }
+    }
+}

--- a/Assets/CMS/FollowCamera.cs.meta
+++ b/Assets/CMS/FollowCamera.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45bfea4d988e904438867b51496d9317
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/IState.cs
+++ b/Assets/CMS/IState.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IState
+{
+    //상태가 시작될 때 호출
+    public void EnterState();
+    //매 프레임마다 호출
+    public void UpdateState();
+    //상태가 종료될 때 호출
+    public void ExitState();
+}

--- a/Assets/CMS/IState.cs.meta
+++ b/Assets/CMS/IState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: da1fdc3270af75048ac403a7f90c2474
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/Monster.cs
+++ b/Assets/CMS/Monster.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Monster : MonoBehaviour
+{
+    public Transform Player { get; private set; }
+    public Vector2 SpawnPoint { get; private set; }
+
+    [SerializeField] private PatrolState _patrolState;
+    [SerializeField] private ChaseState _chaseState;
+    [SerializeField] private AttackState _attackState;
+
+    [SerializeField] private float _visionRadius = 5f;
+    [SerializeField] private float _attackRadius = 1.5f;
+    [SerializeField] private LayerMask _playerLayer;
+
+    private MonsterStateContext _fsm;
+
+    private void Awake()
+    {
+        Player = GameObject.FindGameObjectWithTag("Player").transform;
+        SpawnPoint = transform.position;
+        _fsm = new MonsterStateContext(this);
+    }
+
+    private void Start()
+    {
+        _fsm.Transition(_patrolState);
+    }
+
+    private void Update()
+    {
+        bool playerInVision = Player != null && Vector2.Distance(transform.position, Player.position) <= _visionRadius;
+        bool playerInAttack = Player != null && Vector2.Distance(transform.position, Player.position) <= _attackRadius;
+        
+        if (playerInAttack)
+        {
+            _fsm.Transition(_attackState);
+        }
+        else if (playerInVision)
+        {
+            _fsm.Transition(_chaseState);
+        }
+        else
+        {
+            _fsm.Transition(_patrolState);
+        }
+
+        _fsm.CurrentState?.UpdateState();
+    }
+
+    private void OnDrawGizmosSelected()
+    {
+        Gizmos.color = Color.green;
+        Gizmos.DrawWireSphere(transform.position, _visionRadius);
+        
+        Gizmos.color = Color.red;
+        Gizmos.DrawWireSphere(transform.position, _attackRadius);
+    }
+}

--- a/Assets/CMS/Monster.cs.meta
+++ b/Assets/CMS/Monster.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23c3f678fcdd6c34c8a785ebe7880ac7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/MonsterStateContext.cs
+++ b/Assets/CMS/MonsterStateContext.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MonsterStateContext
+{
+    public IState CurrentState { get; private set; }
+    private readonly Monster _controller;
+
+    public MonsterStateContext(Monster controller)
+    {
+        _controller = controller;
+    }
+
+    public void Transition(IState newState)
+    {
+        if (CurrentState != null)
+        {
+            CurrentState.ExitState();
+        }
+        CurrentState = newState;
+        CurrentState.EnterState();
+    }
+}

--- a/Assets/CMS/MonsterStateContext.cs.meta
+++ b/Assets/CMS/MonsterStateContext.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4305d32aad3b4c84dbdc8b97988848d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/MonsterStats.cs
+++ b/Assets/CMS/MonsterStats.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MonsterStats : MonoBehaviour
+{
+
+    [SerializeField] private float _maxHealth = 100f;
+    private float _currentHealth;
+
+    public float Health => _currentHealth;
+
+    private void Awake()
+    {
+        _currentHealth = _maxHealth;
+    }
+
+    public void TakeDamage(float damage)
+    {
+        _currentHealth -= damage;
+        _currentHealth = Mathf.Clamp(_currentHealth, 0, _maxHealth);
+        
+        Debug.Log($"몬스터 피격: {damage}, 현재 체력: {_currentHealth}");
+
+        if (_currentHealth <= 0)
+        {
+            Die();
+        }
+    }
+    private void Die()
+    {
+        Debug.Log("몬스터 사망");
+        Destroy(gameObject);
+    }
+}

--- a/Assets/CMS/MonsterStats.cs.meta
+++ b/Assets/CMS/MonsterStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09a63a942f03f0f4292149513f3ab4c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/PatrolState.cs
+++ b/Assets/CMS/PatrolState.cs
@@ -1,0 +1,49 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+public class PatrolState : MonoBehaviour, IState
+{
+    private Monster _monster;
+    private Rigidbody2D _rb;
+
+    [SerializeField] private float _patrolDistance = 3f;
+    [SerializeField] private float _patrolSpeed = 2f;
+
+    private Vector2 _leftBound;
+    private Vector2 _rightBound;
+    private int _direction = 1;
+    public void EnterState()
+    {
+        if (!_monster) _monster = GetComponent<Monster>();
+        if (!_rb) _rb = GetComponent<Rigidbody2D>();
+
+        Vector2 origin = _monster.SpawnPoint;
+        _leftBound = new Vector2(origin.x - _patrolDistance, origin.y);
+        _rightBound = new Vector2(origin.x + _patrolDistance, origin.y);
+    } 
+
+    public void UpdateState()
+    {
+        Vector2 newPosition = _rb.position + Vector2.right * _direction * _patrolSpeed * Time.fixedDeltaTime;
+        _rb.MovePosition(newPosition);
+
+        if(_direction == 1 && newPosition.x >= _rightBound.x)
+        {
+            _direction = -1; // 방향을 왼쪽으로 변경
+        }
+        else if(_direction == -1 && newPosition.x <= _leftBound.x)
+        {
+            _direction = 1; // 방향을 오른쪽으로 변경
+        }
+    }
+
+    public void ExitState()
+    {
+    
+    }
+
+   
+
+}

--- a/Assets/CMS/PatrolState.cs.meta
+++ b/Assets/CMS/PatrolState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0030c4d166212f4c87cf58025aa66df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/Player.prefab
+++ b/Assets/CMS/Player.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 8916221334217874197}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/CMS/Player.prefab
+++ b/Assets/CMS/Player.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9162771540310933599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6510858786333333916}
+  - component: {fileID: 5517580932697951082}
+  - component: {fileID: 8902011560828426061}
+  - component: {fileID: 6503298996901883522}
+  - component: {fileID: 8916221334217874197}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6510858786333333916
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9162771540310933599}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5517580932697951082
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9162771540310933599}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -9095717837082945937, guid: 207ee8102dd4143d288186ef0be518ee, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &8902011560828426061
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9162771540310933599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 052481b3e4e33424f9f33360690f33db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!50 &6503298996901883522
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9162771540310933599}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!114 &8916221334217874197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9162771540310933599}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d6ce3e74899c694f8eae1f4673908e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _maxHealth: 100
+  _maxHydration: 100
+  _maxHunger: 100
+  _moveSpeed: 5
+  _runSpeed: 7

--- a/Assets/CMS/Player.prefab.meta
+++ b/Assets/CMS/Player.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 39a948792fb5ae148bcc2186517eb9cd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/PlayerMovement.cs
+++ b/Assets/CMS/PlayerMovement.cs
@@ -4,8 +4,7 @@ using UnityEngine;
 
 public class PlayerMovement : MonoBehaviour
 {
-    [SerializeField] private float _moveSpeed = 5f;
-
+    private PlayerStats _playerStats;
     private Rigidbody2D _rb;
     private Vector2 _moveInput;
 

--- a/Assets/CMS/PlayerMovement.cs
+++ b/Assets/CMS/PlayerMovement.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerMovement : MonoBehaviour
+{
+    [SerializeField] private float _moveSpeed = 5f;
+
+    private Rigidbody2D _rb;
+    private Vector2 _moveInput;
+
+    private void Awake()
+    {
+        _rb = GetComponent<Rigidbody2D>();
+    }
+
+    private void Update()
+    {
+        _moveInput.x = Input.GetAxisRaw("Horizontal");
+        _moveInput.y = Input.GetAxisRaw("Vertical");
+        _moveInput.Normalize();
+    }
+
+    private void FixedUpdate()
+    {
+        _rb.MovePosition(_rb.position + _moveInput * _moveSpeed * Time.fixedDeltaTime);
+    }
+}

--- a/Assets/CMS/PlayerMovement.cs
+++ b/Assets/CMS/PlayerMovement.cs
@@ -11,6 +11,7 @@ public class PlayerMovement : MonoBehaviour
     private void Awake()
     {
         _rb = GetComponent<Rigidbody2D>();
+        _playerStats = GetComponent<PlayerStats>();
     }
 
     private void Update()
@@ -18,10 +19,28 @@ public class PlayerMovement : MonoBehaviour
         _moveInput.x = Input.GetAxisRaw("Horizontal");
         _moveInput.y = Input.GetAxisRaw("Vertical");
         _moveInput.Normalize();
+
+        if(Input.GetKeyDown(KeyCode.LeftShift))
+        {
+            Debug.Log("Shift");
+        }
+        
     }
 
     private void FixedUpdate()
     {
-        _rb.MovePosition(_rb.position + _moveInput * _moveSpeed * Time.fixedDeltaTime);
+        float speed;
+        if (Input.GetKey(KeyCode.LeftShift))
+        {
+            speed = _playerStats.RunSpeed;
+        }
+        else
+        {
+            speed = _playerStats.MoveSpeed;
+        }
+
+        Debug.Log($"Speed: {speed}");
+
+        _rb.MovePosition(_rb.position + _moveInput * speed * Time.fixedDeltaTime);
     }
 }

--- a/Assets/CMS/PlayerMovement.cs.meta
+++ b/Assets/CMS/PlayerMovement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 052481b3e4e33424f9f33360690f33db
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/CMS/PlayerStats.cs
+++ b/Assets/CMS/PlayerStats.cs
@@ -8,6 +8,7 @@ public class PlayerStats : MonoBehaviour
     [SerializeField] private float _maxHydration = 100f;
     [SerializeField] private float _maxHunger = 100f;
     [SerializeField] private float _moveSpeed = 5f;
+    [SerializeField] private float _runSpeed = 7f;
 
     private float _currentHealth;
     private float _currentHydration;
@@ -17,6 +18,7 @@ public class PlayerStats : MonoBehaviour
     public float Hydration => _currentHydration;
     public float Hunger => _currentHunger;
     public float MoveSpeed => _moveSpeed;
+    public float RunSpeed => _runSpeed;
 
     private void Awake()
     {
@@ -25,21 +27,32 @@ public class PlayerStats : MonoBehaviour
         _currentHunger = _maxHunger;
     }
 
-    private void Update()
+    private void Start()
     {
-        DecreaseSurvivalStats();
-        CheckDeath();
+        StartCoroutine(SurvivalStatRoutine());
     }
 
+    private IEnumerator SurvivalStatRoutine()
+    {
+        while (_currentHealth > 0)
+        {
+            DecreaseSurvivalStats();
+            CheckDeath();
 
-    //수분과 허기 감소 수치와 수분과 허기가 0일때 감소하는 체력의 양은 임의로 정해놓음.
-    //매프레임마다 수분과 허기 감소. 수분이 0이거나 허기가 0일때 체력 감소.
+            Debug.Log($"Health: {_currentHealth}, Hydration: {_currentHydration}, Hunger: {_currentHunger}");
+
+            yield return new WaitForSeconds(1f); // 1초 간격
+        }
+    }
+
     private void DecreaseSurvivalStats()
     {
-        float decreaseRate = Time.deltaTime;
+        float hydrationDecreaseRate = 0.5f; // 수분 감소
+        float hungerDecreaseRate = 0.3f; // 허기 감소
+        float decreaseRate = 1f; // 건강 감소
 
-        _currentHydration -= decreaseRate * 1f;
-        _currentHunger -= decreaseRate * 0.8f;
+        _currentHydration -= hydrationDecreaseRate;
+        _currentHunger -= hungerDecreaseRate;
 
         _currentHydration = Mathf.Clamp(_currentHydration, 0, _maxHydration);
         _currentHunger = Mathf.Clamp(_currentHunger, 0, _maxHunger);
@@ -57,20 +70,5 @@ public class PlayerStats : MonoBehaviour
         {
             Debug.Log("플레이어 사망");
         }
-    }
-
-    public void SaveStatsToData(SaveData data)
-    {
-        data.currentHealth = _currentHealth;
-        data.currentHydration = _currentHydration;
-        data.currentHunger = _currentHunger;
-    }
-
-    //불러오기용
-    public void ApplySavedStats(SaveData data)
-    {
-        _currentHealth = Mathf.Clamp(data.currentHealth, 0, _maxHealth);
-        _currentHydration = Mathf.Clamp(data.currentHydration, 0, _maxHydration);
-        _currentHunger = Mathf.Clamp(data.currentHunger, 0, _maxHunger);
     }
 }

--- a/Assets/CMS/PlayerStats.cs
+++ b/Assets/CMS/PlayerStats.cs
@@ -1,0 +1,76 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerStats : MonoBehaviour
+{
+    [SerializeField] private float _maxHealth = 100f;
+    [SerializeField] private float _maxHydration = 100f;
+    [SerializeField] private float _maxHunger = 100f;
+    [SerializeField] private float _moveSpeed = 5f;
+
+    private float _currentHealth;
+    private float _currentHydration;
+    private float _currentHunger;
+
+    public float Health => _currentHealth;
+    public float Hydration => _currentHydration;
+    public float Hunger => _currentHunger;
+    public float MoveSpeed => _moveSpeed;
+
+    private void Awake()
+    {
+        _currentHealth = _maxHealth;
+        _currentHydration = _maxHydration;
+        _currentHunger = _maxHunger;
+    }
+
+    private void Update()
+    {
+        DecreaseSurvivalStats();
+        CheckDeath();
+    }
+
+
+    //수분과 허기 감소 수치와 수분과 허기가 0일때 감소하는 체력의 양은 임의로 정해놓음.
+    //매프레임마다 수분과 허기 감소. 수분이 0이거나 허기가 0일때 체력 감소.
+    private void DecreaseSurvivalStats()
+    {
+        float decreaseRate = Time.deltaTime;
+
+        _currentHydration -= decreaseRate * 1f;
+        _currentHunger -= decreaseRate * 0.8f;
+
+        _currentHydration = Mathf.Clamp(_currentHydration, 0, _maxHydration);
+        _currentHunger = Mathf.Clamp(_currentHunger, 0, _maxHunger);
+
+        if (_currentHydration <= 0 || _currentHunger <= 0)
+        {
+            _currentHealth -= decreaseRate * 5f;
+            _currentHealth = Mathf.Clamp(_currentHealth, 0, _maxHealth);
+        }
+    }
+
+    private void CheckDeath()
+    {
+        if (_currentHealth <= 0f)
+        {
+            Debug.Log("플레이어 사망");
+        }
+    }
+
+    public void SaveStatsToData(SaveData data)
+    {
+        data.currentHealth = _currentHealth;
+        data.currentHydration = _currentHydration;
+        data.currentHunger = _currentHunger;
+    }
+
+    //불러오기용
+    public void ApplySavedStats(SaveData data)
+    {
+        _currentHealth = Mathf.Clamp(data.currentHealth, 0, _maxHealth);
+        _currentHydration = Mathf.Clamp(data.currentHydration, 0, _maxHydration);
+        _currentHunger = Mathf.Clamp(data.currentHunger, 0, _maxHunger);
+    }
+}

--- a/Assets/CMS/PlayerStats.cs
+++ b/Assets/CMS/PlayerStats.cs
@@ -71,4 +71,17 @@ public class PlayerStats : MonoBehaviour
             Debug.Log("플레이어 사망");
         }
     }
+
+    public void TakeDamage(float damage)
+    {
+        _currentHealth -= damage;
+        _currentHealth = Mathf.Clamp(_currentHealth, 0, _maxHealth);
+
+        Debug.Log($"플레이어가 {damage}의 피해를 받았습니다. 현재 체력: {_currentHealth}");
+
+        if(_currentHealth < 0)
+        {
+            CheckDeath();
+        }
+    }
 }

--- a/Assets/CMS/PlayerStats.cs.meta
+++ b/Assets/CMS/PlayerStats.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d6ce3e74899c694f8eae1f4673908e2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/SceneTemplateSettings.json
+++ b/ProjectSettings/SceneTemplateSettings.json
@@ -1,0 +1,121 @@
+{
+    "templatePinStates": [],
+    "dependencyTypeInfos": [
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimationClip",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Animations.AnimatorController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.AnimatorOverrideController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.Audio.AudioMixerController",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ComputeShader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Cubemap",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.GameObject",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.LightingDataAsset",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.LightingSettings",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Material",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.MonoScript",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicMaterial",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.PhysicsMaterial2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.PostProcessing.PostProcessResources",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Rendering.VolumeProfile",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEditor.SceneAsset",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Shader",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.ShaderVariantCollection",
+            "defaultInstantiationMode": 1
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Texture2D",
+            "defaultInstantiationMode": 0
+        },
+        {
+            "userAdded": false,
+            "type": "UnityEngine.Timeline.TimelineAsset",
+            "defaultInstantiationMode": 0
+        }
+    ],
+    "defaultDependencyTypeInfo": {
+        "userAdded": false,
+        "type": "<default_scene_template_dependencies>",
+        "defaultInstantiationMode": 1
+    },
+    "newSceneOverride": 0
+}


### PR DESCRIPTION
플레이어 이동과 플레이어 스탯 구현(체력, 수분, 허기) 스태미너 추가 예정
카메라 - 플레이어를 부드럽게 따라다니도록 구현
몬스터 AI
-몬스터가 스폰되면 어느 지점에 X좌표를 기준으로 순찰(순찰하는 범위를 원으로 변경해야 할 수도 있을 것으로 보임)
-몬스터의 감지범위에 플레이어가 들어오면 추적 후 공격
