### PR TITLE
[Fix] QuitDeathPanel, Reset Collection 

### DIFF
--- a/Assets/01.Scenes/MainScene.unity
+++ b/Assets/01.Scenes/MainScene.unity
@@ -1095,7 +1095,7 @@ MonoBehaviour:
   m_text: "\uB124"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
-  m_sharedMaterial: {fileID: -6638094663087109030, guid: fdd9b5e91c622a845abef46d7f611e49, type: 2}
+  m_sharedMaterial: {fileID: 170552620760400497, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1952,7 +1952,7 @@ MonoBehaviour:
   m_text: "\uC544\uB2C8\uC694"
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
-  m_sharedMaterial: {fileID: -6638094663087109030, guid: fdd9b5e91c622a845abef46d7f611e49, type: 2}
+  m_sharedMaterial: {fileID: 170552620760400497, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2086,8 +2086,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: fdd9b5e91c622a845abef46d7f611e49, type: 2}
-  m_sharedMaterial: {fileID: -6638094663087109030, guid: fdd9b5e91c622a845abef46d7f611e49, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
+  m_sharedMaterial: {fileID: 170552620760400497, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -2462,7 +2462,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 114827750117084474, guid: f32d628d70fd4a04dafdc10352f00f7c, type: 3}
       propertyPath: m_text
-      value: "\uB124 "
+      value: "\uB124"
       objectReference: {fileID: 0}
     - target: {fileID: 114827750117084474, guid: f32d628d70fd4a04dafdc10352f00f7c, type: 3}
       propertyPath: m_fontAsset
@@ -3762,8 +3762,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: "\uD0C0\uC774\uD2C0\uB85C \uB3CC\uC544\uAC00\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?"
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: fdd9b5e91c622a845abef46d7f611e49, type: 2}
-  m_sharedMaterial: {fileID: -6638094663087109030, guid: fdd9b5e91c622a845abef46d7f611e49, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
+  m_sharedMaterial: {fileID: 170552620760400497, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4974,8 +4974,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: GAME OVER
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontAsset: {fileID: 11400000, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
+  m_sharedMaterial: {fileID: 170552620760400497, guid: 4395fcfa5c5dde941a45bf9e8fa47be3, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []

--- a/Assets/PJW/Script/Collection/ItemCollectionManager.cs
+++ b/Assets/PJW/Script/Collection/ItemCollectionManager.cs
@@ -17,6 +17,7 @@ public class ItemCollectionManager : MonoBehaviour
     public IReadOnlyCollection<int> CollectedItemIds => _collectedItemIds;
 
     private const string COLLECTED_ITEMS_KEY = "CollectedItemIds";
+    private const string VERSION_KEY = "SaveVersion";
 
     private void Awake()
     {
@@ -28,6 +29,13 @@ public class ItemCollectionManager : MonoBehaviour
 
         Instance = this;
         DontDestroyOnLoad(gameObject);
+        string savedVersion = PlayerPrefs.GetString(VERSION_KEY, "");
+        if (savedVersion != Application.version)
+        {
+            PlayerPrefs.DeleteKey(COLLECTED_ITEMS_KEY);
+            PlayerPrefs.SetString(VERSION_KEY, Application.version);
+            PlayerPrefs.Save();
+        }
 
         LoadCollectedItems(); 
     }


### PR DESCRIPTION
게임 시작시 수집품 UI에 이미 오브젝트가 등록되어 있는 이슈 수정
죽음 퀵 판넬 폰트 수정

주의사항)
빌드시마다 도감 초기화를 해 놨기 때문에
Bulid를 할 때 PlayerSetting에서 버전을 무조건 바꿔줘야 합니다!