### PR TITLE
[Fix] Inventory Bug Fix

### DIFF
--- a/Assets/01.Scenes/MainScene.unity
+++ b/Assets/01.Scenes/MainScene.unity
@@ -3080,6 +3080,215 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 13a21a8ec4a507f48a89a89d1e996503, type: 3}
+--- !u!1001 &1191202459
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1259517615893832413, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1259517615893832413, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883964871914809514, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883964871914809514, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883964871914809514, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2883964871914809514, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5031195176786126385, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5031195176786126385, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5031195176786126385, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5031195176786126385, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5521803694921561743, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_Name
+      value: InventoryManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 6399513524967273736, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6399513524967273736, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6399513524967273736, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6399513524967273736, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 41.485535
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -22.328033
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.32492423
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6451624816636183270, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7063390137149198032, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7063390137149198032, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7063390137149198032, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7063390137149198032, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7372620130183599983, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7372620130183599983, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7372620130183599983, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7372620130183599983, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396990577388657178, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396990577388657178, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396990577388657178, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7396990577388657178, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7667166380275142657, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7667166380275142657, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7667166380275142657, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7667166380275142657, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064547372086845475, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064547372086845475, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064547372086845475, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8064547372086845475, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8984842064282476012, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8984842064282476012, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8984842064282476012, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8984842064282476012, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a5c44af7b7133684ebaf15dce49f8d00, type: 3}
 --- !u!1 &1200857502
 GameObject:
   m_ObjectHideFlags: 0
@@ -6627,3 +6836,4 @@ SceneRoots:
   - {fileID: 1046392811}
   - {fileID: 2038653979}
   - {fileID: 1161094696}
+  - {fileID: 1191202459}

--- a/Assets/CMS/Script/Player/PlayerMovement.cs
+++ b/Assets/CMS/Script/Player/PlayerMovement.cs
@@ -47,28 +47,13 @@ public class PlayerMovement : MonoBehaviour
         }
 
         if (Input.GetKeyDown(KeyCode.Z)) {
-            if (_craftingPanel.activeSelf == false) {
-                _craftingPanel.SetActive(true);
-            }
-            else {
-                _craftingPanel.SetActive(false);
-            }
+            InventoryManager.Instance.OpenCraftingPanel();
         }
         if (Input.GetKeyDown(KeyCode.Tab)) {
-            if (_inventoryPanel.activeSelf == false) {
-                _inventoryPanel.SetActive(true);
-            }
-            else {
-                _inventoryPanel.SetActive(false);
-            }
+            InventoryManager.Instance.OpenInventory();
         }
         if (Input.GetKeyDown(KeyCode.X)) {
-            if (_decompositionPanel.activeSelf == false) {
-                _decompositionPanel.SetActive(true);
-            }
-            else {
-                _decompositionPanel.SetActive(false);
-            }
+            InventoryManager.Instance.OpenDecompositionPanel();
         }
 
         _anim.SetFloat("Horizontal", 1f);

--- a/Assets/LHW/Prefabs/InventoryManager.meta
+++ b/Assets/LHW/Prefabs/InventoryManager.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ea4f662067e7ca44a06b93fecce7d4b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHW/Prefabs/InventoryManager/InventoryManager.prefab
+++ b/Assets/LHW/Prefabs/InventoryManager/InventoryManager.prefab
@@ -1,0 +1,387 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5521803694921561743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6451624816636183270}
+  - component: {fileID: 7804364764511303215}
+  m_Layer: 0
+  m_Name: InventoryManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6451624816636183270
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5521803694921561743}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 41.485535, y: -22.328033, z: -0.32492423}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3036782592769532658}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7804364764511303215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5521803694921561743}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58c791e4b76789544a85ee1e5645459d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _decompositionSlotData: {fileID: 449927295932232302}
+  _boxSlotData: []
+  _hotbarController: {fileID: 1709329563401097202}
+  _gameManager: {fileID: 0}
+  _inventoryController: {fileID: 7461540727834692147}
+  _craftingController: {fileID: 8572854872315137183}
+  _decompositionController: {fileID: 5338102475111769372}
+  _repairController: {fileID: 1144172323901661543}
+  _boxController: {fileID: 104443197528854539}
+--- !u!1001 &583275969238465183
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6451624816636183270}
+    m_Modifications:
+    - target: {fileID: 1829168427907422274, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1829168427907422274, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314235178804122165, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314235178804122165, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314235178804122165, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2314235178804122165, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4055029215063264993, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_Name
+      value: Inven&apllication UICanvas
+      objectReference: {fileID: 0}
+    - target: {fileID: 5605384203438136494, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5605384203438136494, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5605384203438136494, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5605384203438136494, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5825289304800333719, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5825289304800333719, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5825289304800333719, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5825289304800333719, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7097401794315479710, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7097401794315479710, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7097401794315479710, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7097401794315479710, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490385014764411580, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490385014764411580, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490385014764411580, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7490385014764411580, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7646555330582443087, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7646555330582443087, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7646555330582443087, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7646555330582443087, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7946874861514010096, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7946874861514010096, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7946874861514010096, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7946874861514010096, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980191461198225541, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980191461198225541, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980191461198225541, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7980191461198225541, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8406149194799228787, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8406149194799228787, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8406149194799228787, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8406149194799228787, guid: 37549567957b1904e97358269b9651d2, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 37549567957b1904e97358269b9651d2, type: 3}
+--- !u!114 &104443197528854539 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 678698771211823764, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f33bdc7a0de5f2842946069bf6819d46, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &449927295932232302 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1019572849023650033, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1eac9f594adf6740aa224012bdcd6db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1144172323901661543 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 574451728863665144, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5f30de9dd006244fac272b4bd2dedd3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1709329563401097202 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2279090006605854061, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2072b40463731e4db67c91dea1ce035, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3036782592769532658 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2467101554661185645, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5338102475111769372 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4759330142555299715, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfc7bf2a1b2f4b04f9d3ca72b4eef62f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &7461540727834692147 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8040193780831793324, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d9572e6581ab12147bd8e4fe9cadc872, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8572854872315137183 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 9142536433874564608, guid: 37549567957b1904e97358269b9651d2, type: 3}
+  m_PrefabInstance: {fileID: 583275969238465183}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3f3e6d32dcd7a764dae69c43fafd460a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/LHW/Prefabs/InventoryManager/InventoryManager.prefab.meta
+++ b/Assets/LHW/Prefabs/InventoryManager/InventoryManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a5c44af7b7133684ebaf15dce49f8d00
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHW/Prefabs/New Folder.meta
+++ b/Assets/LHW/Prefabs/New Folder.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7ea4f662067e7ca44a06b93fecce7d4b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/LHW/Scripts/Box/BoxController.cs
+++ b/Assets/LHW/Scripts/Box/BoxController.cs
@@ -15,9 +15,9 @@ public class BoxController : UIBase
 
     private void OnEnable()
     {
+        _data = InventoryManager.Instance.CurrentOpenedBox;
         _data.OnBoxSlotUpdated += UpdateUISlot;
-        UpdateUISlot();
-        InventoryManager.Instance.OpenBox(this._data);
+        UpdateUISlot();        
     }
 
     private void OnDisable()

--- a/Assets/LHW/Scripts/Crafting/UI/CraftingController.cs
+++ b/Assets/LHW/Scripts/Crafting/UI/CraftingController.cs
@@ -155,7 +155,7 @@ public class CraftingController : UIBase
 
     public void GoToRepairMenu()
     {
-        GameManager.Instance.InGameUIManager.ShowUI(UIType.Repair);
+        InventoryManager.Instance.OpenRepairPanel();
     }
 
     #region unused code

--- a/Assets/LHW/Scripts/Inventory/InventoryController.cs
+++ b/Assets/LHW/Scripts/Inventory/InventoryController.cs
@@ -5,6 +5,7 @@ public class InventoryController : MonoBehaviour
 {
     [SerializeField] InventorySlotUnit[] slots;
     [SerializeField] TMP_Text _weightText;
+    [SerializeField] InventoryManager _inventoryManager;
 
     private void Start()
     {
@@ -37,8 +38,8 @@ public class InventoryController : MonoBehaviour
     }
 
     private void UpdateWeightText()
-    {
-        PlayerStats stats = GameObject.FindWithTag("Player").GetComponent<PlayerStats>();
+    {        
+        PlayerStats stats = GameManager.Instance.PlayerStats;
 
         float weight = stats.CurrentInventoryWeight;
         float maxWeight = stats.MaxInventoryWeight;

--- a/Assets/LHW/Scripts/Inventory/InventoryManager.cs
+++ b/Assets/LHW/Scripts/Inventory/InventoryManager.cs
@@ -34,11 +34,12 @@ public class InventoryManager : MonoBehaviour
     #endregion
 
     [SerializeField] DecompositionSystem _decompositionSlotData;
-    [SerializeField] BoxSystem[] _boxSlotData;
+
     [SerializeField] HotbarController _hotbarController;
-    [SerializeField] PlayerStats _playerStats;
+    [SerializeField] GameManager _gameManager;
 
     private BoxSystem _currentOpenedBox;
+    public BoxSystem CurrentOpenedBox => _currentOpenedBox;
 
     public int InventoryCount => _inventoryItem.Length;
 
@@ -46,6 +47,78 @@ public class InventoryManager : MonoBehaviour
     private int[] _inventoryStack;
 
     public static event Action OnInventorySlotChanged;
+
+    [SerializeField] InventoryController _inventoryController;
+
+    [SerializeField] CraftingController _craftingController;
+
+    [SerializeField] DecompositionController _decompositionController;
+
+    [SerializeField] RepairController _repairController;
+
+    [SerializeField] BoxController _boxController;
+    public BoxController BoxController => _boxController;
+
+    public void OpenInventory()
+    {
+        if (_inventoryController.gameObject.activeSelf)
+        {
+            _inventoryController.gameObject.SetActive(false);
+        }
+        else
+        {
+            _inventoryController.gameObject.SetActive(true);
+        }
+    }
+
+    public void OpenCraftingPanel()
+    {
+        if (_craftingController.gameObject.activeSelf)
+        {
+            _craftingController.gameObject.SetActive(false);
+        }
+        else
+        {
+            _craftingController.gameObject.SetActive(true);
+        }
+    }
+
+    public void OpenDecompositionPanel()
+    {
+        if (_decompositionController.gameObject.activeSelf)
+        {
+            _decompositionController.gameObject.SetActive(false);
+        }
+        else
+        {
+            _decompositionController.gameObject.SetActive(true);
+        }
+
+    }
+
+    public void OpenRepairPanel()
+    {
+        if (_repairController.gameObject.activeSelf)
+        {
+            _repairController.gameObject.SetActive(false);
+        }
+        else
+        {
+            _repairController.gameObject.SetActive(true);
+        }
+    }
+
+    public void OpenBoxPanel()
+    {
+        if (_boxController.gameObject.activeSelf)
+        {
+            _boxController.gameObject.SetActive(false);
+        }
+        else
+        {
+            _boxController.gameObject.SetActive(true);
+        }
+    }
 
     #region Inventory
 
@@ -83,9 +156,9 @@ public class InventoryManager : MonoBehaviour
             for (int i = 0; i < _inventoryStack[startIndex]; i++)
             {
                 // TODO : Where to Instantiate item?
-                Instantiate(_inventoryItem[startIndex].Prefab, position + new Vector3(1, 0 , -5), Quaternion.identity);
+                Instantiate(_inventoryItem[startIndex].Prefab, position + new Vector3(1, 0, -5), Quaternion.identity);
             }
-            _playerStats.RemoveInventoryWeight(_inventoryItem[startIndex].Weight * _inventoryStack[startIndex]);
+            GameManager.Instance.PlayerStats.RemoveInventoryWeight(_inventoryItem[startIndex].Weight * _inventoryStack[startIndex]);
             _inventoryItem[startIndex] = null;
             _inventoryStack[startIndex] = 0;
             OnInventorySlotChanged?.Invoke();
@@ -149,19 +222,19 @@ public class InventoryManager : MonoBehaviour
                     remain = InventoryTryAdd(item, i, remain);
                     if (remain <= 0) break;
                 }
-            }            
+            }
 
             if (remain <= 0) break;
 
             else
             {
-                _playerStats.AddInventoryWeight(item.Weight * (amount - remain));
+                GameManager.Instance.PlayerStats.AddInventoryWeight(item.Weight * (amount - remain));
                 OnInventorySlotChanged?.Invoke();
                 Debug.Log("inventory full"); return false;
             }
         }
         Debug.Log("Weight Up1");
-        _playerStats.AddInventoryWeight(item.Weight * amount);
+        GameManager.Instance.PlayerStats.AddInventoryWeight(item.Weight * amount);
         OnInventorySlotChanged?.Invoke();
         return true;
     }
@@ -175,7 +248,7 @@ public class InventoryManager : MonoBehaviour
     {
         if (_inventoryItem[index].Type == ItemType.Usable || _inventoryItem[index].Type == ItemType.Equip)
         {
-            _playerStats.RemoveInventoryWeight(_inventoryItem[index].Weight);
+            GameManager.Instance.PlayerStats.RemoveInventoryWeight(_inventoryItem[index].Weight);
             _inventoryStack[index]--;
             if (_inventoryStack[index] <= 0)
             {
@@ -196,9 +269,9 @@ public class InventoryManager : MonoBehaviour
     public bool RemoveItemFromInventory(ItemSO item, int amount = 1)
     {
         int remain = amount;
-        while(remain > 0)
+        while (remain > 0)
         {
-            for(int i = 0; i < _inventoryItem.Length;i++)
+            for (int i = 0; i < _inventoryItem.Length; i++)
             {
                 if (_inventoryItem[i] == item)
                 {
@@ -206,14 +279,14 @@ public class InventoryManager : MonoBehaviour
                     if (remain <= 0) break;
                 }
             }
-            if(remain <= 0) break;
+            if (remain <= 0) break;
 
-            _playerStats.RemoveInventoryWeight(item.Weight * (amount - remain));
+            GameManager.Instance.PlayerStats.RemoveInventoryWeight(item.Weight * (amount - remain));
             OnInventorySlotChanged?.Invoke();
             return false;
         }
 
-        _playerStats.RemoveInventoryWeight(item.Weight * amount);
+        GameManager.Instance.PlayerStats.RemoveInventoryWeight(item.Weight * amount);
         OnInventorySlotChanged?.Invoke();
         return true;
     }
@@ -224,7 +297,7 @@ public class InventoryManager : MonoBehaviour
         {
             if (_inventoryItem[i] != null)
             {
-                _playerStats.RemoveInventoryWeight(_inventoryItem[i].Weight * _inventoryStack[i]);
+                GameManager.Instance.PlayerStats.RemoveInventoryWeight(_inventoryItem[i].Weight * _inventoryStack[i]);
                 _inventoryItem[i] = null;
                 _inventoryStack[i] = 0;
             }
@@ -253,7 +326,7 @@ public class InventoryManager : MonoBehaviour
         else if (item.MaxStackSize > _inventoryStack[index])
         {
             amount -= (item.MaxStackSize - _inventoryStack[index]);
-            _inventoryStack[index] = item.MaxStackSize;            
+            _inventoryStack[index] = item.MaxStackSize;
             OnInventorySlotChanged?.Invoke();
             return amount;
         }
@@ -262,7 +335,7 @@ public class InventoryManager : MonoBehaviour
         {
             return amount;
         }
-    }    
+    }
 
     /// <summary>
     /// Try remove item.
@@ -272,7 +345,7 @@ public class InventoryManager : MonoBehaviour
     /// <returns></returns>
     private int InventoryTryRemove(int index, int amount)
     {
-        if(amount <= _inventoryStack[index])
+        if (amount <= _inventoryStack[index])
         {
             _inventoryStack[index] -= amount;
             if (_inventoryStack[index] == 0)
@@ -282,7 +355,7 @@ public class InventoryManager : MonoBehaviour
             OnInventorySlotChanged?.Invoke();
             return 0;
         }
-        else if(amount > _inventoryStack[index])
+        else if (amount > _inventoryStack[index])
         {
             amount -= _inventoryStack[index];
             _inventoryStack[index] = 0;
@@ -322,13 +395,13 @@ public class InventoryManager : MonoBehaviour
     /// <param name="endindex"></param>
     public void SendItemToDecomposition(int startIndex)
     {
-       if(_decompositionSlotData.AddItemToDecompositionSlot(_inventoryItem[startIndex], _inventoryStack[startIndex]))
-       {
-            _playerStats.RemoveInventoryWeight(_inventoryItem[startIndex].Weight * _inventoryStack[startIndex]);
+        if (_decompositionSlotData.AddItemToDecompositionSlot(_inventoryItem[startIndex], _inventoryStack[startIndex]))
+        {
+            GameManager.Instance.PlayerStats.RemoveInventoryWeight(_inventoryItem[startIndex].Weight * _inventoryStack[startIndex]);
             _inventoryItem[startIndex] = null;
-            _inventoryStack[startIndex] = 0;            
+            _inventoryStack[startIndex] = 0;
             OnInventorySlotChanged?.Invoke();
-       }
+        }
     }
 
     /// <summary>
@@ -374,18 +447,12 @@ public class InventoryManager : MonoBehaviour
     {
         if (startIndex == -1) return;
 
-        for (int i = 0; i < _boxSlotData.Length; i++)
+        if (_currentOpenedBox.AddItemToBoxSlot(_inventoryItem[startIndex], _inventoryStack[startIndex]))
         {
-            if (_boxSlotData[i] == _currentOpenedBox)
-            {
-                if (_boxSlotData[i].AddItemToBoxSlot(_inventoryItem[startIndex], _inventoryStack[startIndex]))
-                {
-                    _playerStats.RemoveInventoryWeight(_inventoryItem[startIndex].Weight * _inventoryStack[startIndex]);
-                    _inventoryItem[startIndex] = null;
-                    _inventoryStack[startIndex] = 0;
-                    OnInventorySlotChanged?.Invoke();
-                }
-            }
+            GameManager.Instance.PlayerStats.RemoveInventoryWeight(_inventoryItem[startIndex].Weight * _inventoryStack[startIndex]);
+            _inventoryItem[startIndex] = null;
+            _inventoryStack[startIndex] = 0;
+            OnInventorySlotChanged?.Invoke();
         }
     }
 
@@ -396,10 +463,7 @@ public class InventoryManager : MonoBehaviour
     /// <param name="endIndex"></param>
     public void MoveItemInBoxSlot(int startIndex, int endIndex)
     {
-        for (int i = 0; i < _boxSlotData.Length; i++)
-        {
-            _boxSlotData[i].MoveItemInBoxSlot(startIndex, endIndex);
-        }
+        _currentOpenedBox.MoveItemInBoxSlot(startIndex, endIndex);
     }
 
     #endregion

--- a/Assets/LHW/Scripts/Repair/RepairController.cs
+++ b/Assets/LHW/Scripts/Repair/RepairController.cs
@@ -101,6 +101,6 @@ public class RepairController : UIBase
 
     public void GoBackToCraftUI()
     {
-        GameManager.Instance.InGameUIManager.HideUI();
+        InventoryManager.Instance.OpenRepairPanel();
     }
 }

--- a/Assets/SJW/Script/Interaction/ContainerObject.cs
+++ b/Assets/SJW/Script/Interaction/ContainerObject.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class ContainerObject : MonoBehaviour
@@ -9,16 +7,13 @@ public class ContainerObject : MonoBehaviour
 
     [SerializeField] private GameObject _uiPanel;
 
-
+    [SerializeField] private BoxSystem _boxSystem;
 
     public void OnOpen()
     {
         Debug.Log($"{_itemName} 상호작용");
-
-        if (GameManager.Instance.IsUIOpen == false)
-            GameManager.Instance.InGameUIManager.ShowUI(UIType.Box);
-
-
+        if(!InventoryManager.Instance.BoxController.gameObject.activeSelf) InventoryManager.Instance.OpenBox(_boxSystem);
+            InventoryManager.Instance.OpenBoxPanel();
     }
 }
 


### PR DESCRIPTION
인벤토리 버그 수정

치명적 버그 발생 원인 - 인벤토리 자체는 싱글톤인데 해당 연결된 UI는 싱글톤이 아니다 보니, 게임이 종료된 후 다시 실행하면 인벤토리 UI 자체가 파괴되어 비정상 작동이 일어남. (아이템 사용 불가, 무한 복사 버그 발생)

따라서 인벤토리 매니저 자체에 UI를 자식 오브젝트로 두고 직접 연결하는 방식으로 UI 연결이 해제되지 않는 방법으로 구성함. 이에 따라서 IngameUIManager로 호출하는 방식이 불가능하여 해당 호출 방식을 전부 InventoryManager를 호출하는 방식을 사용했습니다.

사용 의도와는 전혀 다른 방식으로 코드를 구성할 수밖에 없었어서 어쩔 수 없이 많이 뒤엎었습니다... 아무래도 인벤토리를 싱글톤으로 선언한 것부터 시작된 문제인 것 같은데 처음부터 설계하는 데 고민을 많이 했어야 하지 않았나 싶고 씁쓸하네요...

당장 빠듯한 시간 안에 버그 자체를 고치는 데 초점을 둔 방식이라 불편해도 이해 부탁드립니다...